### PR TITLE
Add Intel MacOS Host in Tokyo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,12 +123,12 @@
         username = "jhl";
       };
 
-      # Add more Darwin hosts here following the same pattern:
-      # anotherMac = mkDarwin {
-      #   hostname = "anotherMac";
-      #   system = "aarch64-darwin";  # or "x86_64-darwin" for Intel
-      #   username = "username";
-      # };
+      # Intel Mac Server in Tokyo
+      ap-tokyo-2 = mkDarwin {
+        hostname = "ap-tokyo-2";
+        system = "x86_64-darwin";  # Intel Mac
+        username = "valor";
+      };
     };
 
     # NixOS configurations (for future use)

--- a/home/valor/default.nix
+++ b/home/valor/default.nix
@@ -1,0 +1,64 @@
+{ config, pkgs, ... }:
+
+#############################################################
+#
+#  Home Manager Configuration for valor
+#  User-specific environment and dotfiles
+#
+#############################################################
+
+{
+  imports = [
+    # Import program and shell configurations
+    # ./programs
+    # ./shell
+
+    # Import optional modules as needed:
+    # ../common/optional/vscode.nix
+  ];
+
+  # Home Manager settings
+  home = {
+    username = "valor";
+    homeDirectory = "/Users/valor";
+    stateVersion = "24.05";
+
+    # Disable version mismatch check (we're using unstable nixpkgs with stable darwin)
+    enableNixpkgsReleaseCheck = false;
+
+    # User-specific packages
+    packages = with pkgs; [
+      # Add user-specific packages here
+    ];
+
+    # Environment variables
+    sessionVariables = {
+      EDITOR = "vim";
+    };
+  };
+
+  # Let Home Manager manage itself
+  programs.home-manager.enable = true;
+
+  # Git configuration
+  programs.git = {
+    enable = true;
+    userName = "Valor";
+    userEmail = "valor@example.com";
+    extraConfig = {
+      init.defaultBranch = "main";
+    };
+  };
+
+  # Shell configuration
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+    autosuggestion.enable = true;
+    syntaxHighlighting.enable = true;
+
+    shellAliases = {
+      ll = "ls -lah";
+    };
+  };
+}

--- a/hosts/darwin/ap-tokyo-2/default.nix
+++ b/hosts/darwin/ap-tokyo-2/default.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+
+#############################################################
+#
+#  ap-tokyo-2 - Intel Mac Server
+#  macOS Darwin Configuration
+#
+#############################################################
+
+{
+  imports = [
+    # Host-specific configurations
+  ];
+
+  # Host identification
+  networking.hostName = "ap-tokyo-2";
+  networking.computerName = "ap-tokyo-2";
+  system.defaults.smb.NetBIOSName = "ap-tokyo-2";
+
+  # Disable desktop applications for this host (server use only)
+  # Override the common homebrew casks configuration
+  homebrew = {
+    casks = [
+      # No desktop applications for this server host
+      # Only CLI tools from brews are installed (defined in common/darwin/homebrew.nix)
+    ];
+  };
+
+  # Host-specific settings
+  # Add any machine-specific configuration here
+}

--- a/users/valor/default.nix
+++ b/users/valor/default.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+#############################################################
+#
+#  User: valor
+#  System-level user configuration
+#
+#############################################################
+
+{
+  users.users.valor = {
+    home = "/Users/valor";
+    description = "Valor";
+    shell = pkgs.zsh;
+  };
+
+  # Set as primary user on Darwin
+  system.primaryUser = "valor";
+
+  # Trust this user for Nix operations
+  nix.settings.trusted-users = [ "valor" ];
+}


### PR DESCRIPTION
- Created new user 'valor' with system and home configurations
- Added Intel Mac (x86_64-darwin) host 'ap-tokyo-2'
- Configured host without desktop applications (server use only)
- Desktop apps are only for jhl user, valor user gets CLI tools only
- Added host entry to flake.nix with correct architecture and user mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)