### PR TITLE
Fix zsh deprecation warning and bun installation issue

### DIFF
--- a/home/valor/shell/zsh.nix
+++ b/home/valor/shell/zsh.nix
@@ -31,7 +31,7 @@
       path = "$HOME/.zsh_history";
     };
 
-    initExtra = ''
+    initContent = ''
       # Add Homebrew to PATH (Intel Mac uses /usr/local, Apple Silicon uses /opt/homebrew)
       if [[ $(uname -m) == "x86_64" ]]; then
         export HOMEBREW_PREFIX="/usr/local"

--- a/hosts/darwin/ap-tokyo-2/default.nix
+++ b/hosts/darwin/ap-tokyo-2/default.nix
@@ -25,12 +25,31 @@
   ];
 
   # Disable desktop applications for this host (server use only)
-  # Override the common homebrew casks configuration
+  # Override the common homebrew casks and brews configuration
   homebrew = {
-    casks = [
-      # No desktop applications for this server host
-      # Only CLI tools from brews are installed (defined in common/darwin/homebrew.nix)
+    # Disable all casks (no desktop applications)
+    casks = [];
+
+    # Override brews list - remove bun and mole which have issues on Intel Mac
+    brews = [
+      # Language & Necessary
+      "openssh"
+      "gcc"
+      "go"
+      "rust"
+      "tree"
+      "git"
+      "node"
+      "openjdk"
+
+      # Tools
+      "neofetch"
+      # Removed: "bun" - has permission issues on Intel Mac
+      # Removed: "tw93/tap/mole" - not needed on server
     ];
+
+    # Disable taps that are not needed
+    taps = [];
   };
 
   # Host-specific settings


### PR DESCRIPTION
- Changed initExtra to initContent in valor's zsh config (fixes deprecation warning)
- Removed bun from ap-tokyo-2 brews list (has permission issues on Intel Mac)
- Removed tw93/tap/mole and disabled custom taps (not needed on server)
- Explicitly set empty casks list for clarity

This resolves the Homebrew bundle failure on Intel Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)